### PR TITLE
adf pipline configuration for Olympic data model

### DIFF
--- a/linkedService/AzureDataLakeStorage1.json
+++ b/linkedService/AzureDataLakeStorage1.json
@@ -1,0 +1,12 @@
+{
+	"name": "AzureDataLakeStorage1",
+	"type": "Microsoft.DataFactory/factories/linkedservices",
+	"properties": {
+		"annotations": [],
+		"type": "AzureBlobFS",
+		"typeProperties": {
+			"url": "https://olympicdevadls.dfs.core.windows.net/",
+			"encryptedCredential": "ew0KICAiVmVyc2lvbiI6ICIyMDE3LTExLTMwIiwNCiAgIlByb3RlY3Rpb25Nb2RlIjogIktleSIsDQogICJTZWNyZXRDb250ZW50VHlwZSI6ICJQbGFpbnRleHQiLA0KICAiQ3JlZGVudGlhbElkIjogIkRBVEFGQUNUT1JZQDhENTI0NjkzLUJBODgtNDhEQy1CMTkzLUMwOTYxRjFGODA0Ml8zOGU0ODllZS01M2U4LTRkMGEtODMzZC1jMzRlZTk1NDFkMzMiDQp9"
+		}
+	}
+}

--- a/linkedService/t_oly_git_http_ls.json
+++ b/linkedService/t_oly_git_http_ls.json
@@ -1,0 +1,15 @@
+{
+	"name": "t_oly_git_http_ls",
+	"type": "Microsoft.DataFactory/factories/linkedservices",
+	"properties": {
+		"annotations": [],
+		"type": "HttpServer",
+		"typeProperties": {
+			"url": "https://github.com/ajitdwivedi451",
+			"enableServerCertificateValidation": true,
+			"authenticationType": "Basic",
+			"userName": "ajitdwivedi451",
+			"encryptedCredential": "ew0KICAiVmVyc2lvbiI6ICIyMDE3LTExLTMwIiwNCiAgIlByb3RlY3Rpb25Nb2RlIjogIktleSIsDQogICJTZWNyZXRDb250ZW50VHlwZSI6ICJQbGFpbnRleHQiLA0KICAiQ3JlZGVudGlhbElkIjogIkRBVEFGQUNUT1JZQDhENTI0NjkzLUJBODgtNDhEQy1CMTkzLUMwOTYxRjFGODA0Ml9iOTIyNTJkMS1iZmFiLTQzZGQtODBmOS01OTdiMjdlNDBlYTYiDQp9"
+		}
+	}
+}

--- a/linkedService/tokyo_oly_adls_flatfiles_ls.json
+++ b/linkedService/tokyo_oly_adls_flatfiles_ls.json
@@ -1,0 +1,12 @@
+{
+	"name": "tokyo_oly_adls_flatfiles_ls",
+	"type": "Microsoft.DataFactory/factories/linkedservices",
+	"properties": {
+		"annotations": [],
+		"type": "AzureBlobFS",
+		"typeProperties": {
+			"url": "https://olympicdevadls.dfs.core.windows.net/",
+			"encryptedCredential": "ew0KICAiVmVyc2lvbiI6ICIyMDE3LTExLTMwIiwNCiAgIlByb3RlY3Rpb25Nb2RlIjogIktleSIsDQogICJTZWNyZXRDb250ZW50VHlwZSI6ICJQbGFpbnRleHQiLA0KICAiQ3JlZGVudGlhbElkIjogIkRBVEFGQUNUT1JZQDhENTI0NjkzLUJBODgtNDhEQy1CMTkzLUMwOTYxRjFGODA0Ml81YTQyOTM3Mi1iOTQ4LTQxZTktOWE0Yy02NmE5M2FlNjkzYzMiDQp9"
+		}
+	}
+}


### PR DESCRIPTION
created data model for olymic-dev adf which will extract the data from github and dumped to central storage system adls in their source: data that are dumped is Athletes.csv, Coaches.csv, EntriesGender.csv, Medals.csv, Teams.csv
it has three pipelines and 2 data sets and 2 linked services.